### PR TITLE
fix: invalid link of homepage

### DIFF
--- a/packages/build-plugin-component/CHANGELOG.md
+++ b/packages/build-plugin-component/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.22
+
+- [fix] fix invalid homepage
+
+## 0.2.21
+
+- [feat] support custom unpkgHost
+
 ## 0.2.20
 
 - [fix] fail to create component-demos.js when no node_modules folder

--- a/packages/build-plugin-component/package.json
+++ b/packages/build-plugin-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-component",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "build plugin for component development",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-component/package.json
+++ b/packages/build-plugin-component/package.json
@@ -42,6 +42,7 @@
     "react-dev-utils": "^10.0.0",
     "template-component-demo": "^1.0.0",
     "typescript": "^3.7.3",
+    "url-join": "^4.0.1",
     "user-home": "^2.0.0",
     "utils": "^0.3.1"
   },

--- a/packages/build-plugin-component/src/utils/modifyPkgHomePage.js
+++ b/packages/build-plugin-component/src/utils/modifyPkgHomePage.js
@@ -36,7 +36,7 @@ module.exports = async (pkg, rootDir) => {
     }
   }
 
-  const homepage = `${path.join(unpkgHost, name)}@${version}/build/index.html`;
+  const homepage = `${unpkgHost}/${name}@${version}/build/index.html`;
   fse.writeJsonSync(pkgPath, { ...pkg, homepage }, {
     spaces: 2,
   });

--- a/packages/build-plugin-component/src/utils/modifyPkgHomePage.js
+++ b/packages/build-plugin-component/src/utils/modifyPkgHomePage.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fse = require('fs-extra');
 const npmUtils = require('ice-npm-utils');
 const userHome = require('user-home');
+const urljoin = require('url-join');
 
 module.exports = async (pkg, rootDir) => {
   // modify pkg home page
@@ -36,7 +37,7 @@ module.exports = async (pkg, rootDir) => {
     }
   }
 
-  const homepage = `${unpkgHost}/${name}@${version}/build/index.html`;
+  const homepage = urljoin(unpkgHost, `${name}@${version}`, 'build/index.html');
   fse.writeJsonSync(pkgPath, { ...pkg, homepage }, {
     spaces: 2,
   });


### PR DESCRIPTION
path.join 的拼接会让 // 转化 /，导致 homepage 链接错误