### PR TITLE
Feat: use @iceworks/spec instead

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,3 +1,3 @@
-const { commitlint } = require('@ice/spec');
+const { getCommitlintConfig } = require('@iceworks/spec');
 
-module.exports = commitlint;
+module.exports = getCommitlintConfig('react');

--- a/.eslintignore
+++ b/.eslintignore
@@ -18,6 +18,7 @@ app/build/
 tmp
 .tmp
 __mocks__
+__tests__
 
 # 忽略文件
 **/*-min.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-const { eslint, tslint, deepmerge } = require('@ice/spec');
+const { getESLintConfig } = require('@iceworks/spec');
 
 const commonRules = {
   'react/jsx-filename-extension': [1, { 'extensions': ['.js', '.jsx', '.tsx'] }],
@@ -10,7 +10,7 @@ const commonRules = {
   'class-methods-use-this': 0
 };
 
-const jsRules = deepmerge(eslint, {
+const jsRules = getESLintConfig('react', {
   env: {
     jest: true
   },
@@ -19,7 +19,8 @@ const jsRules = deepmerge(eslint, {
   },
 });
 
-const tsRules = deepmerge(tslint, {
+
+const tsRules = getESLintConfig('react-ts', {
   env: {
     jest: true
   },

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "singleQuote": true,
-  "tabWidth": 2,
-  "useTabs": false,
-  "jsxSingleQuote": true,
-  "printWidth": 120
-}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+const { getPrettierConfig } = require('@iceworks/spec');
+
+module.exports = getPrettierConfig('react');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,5 @@
     "ts-jest": "^25.2.1",
     "ts-node": "^8.10.2",
     "typescript": "^3.8.2"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     }
   },
   "devDependencies": {
-    "@ice/spec": "^1.0.1",
+    "@commitlint/cli": "^11.0.0",
+    "@iceworks/spec": "^1.0.1",
     "@types/jest": "^25.1.3",
     "axios": "^0.19.2",
     "codecov": "^3.6.5",
-    "commitlint": "^8.3.5",
     "eslint": "^6.8.0",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
@@ -32,9 +32,11 @@
     "jest": "^25.1.0",
     "jest-extended": "^0.11.5",
     "lerna": "^3.22.1",
+    "prettier": "^2.1.2",
     "stylelint": "^13.2.0",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.10.2",
     "typescript": "^3.8.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/build-plugin-block/src/ejsRender.js
+++ b/packages/build-plugin-block/src/ejsRender.js
@@ -23,11 +23,11 @@ const ejsRenderDir = async function (dir, data, log) {
           files.map((file) => {
             const filepath = path.join(dir, file);
             return renderFile(filepath, data, log);
-          })
+          }),
         )
           .then(resolve)
           .catch(reject);
-      }
+      },
     );
   });
 };
@@ -41,7 +41,7 @@ async function renderFile(filepath, data, log) {
       await fse.rename(filepath, targetFilePath);
       await fse.writeFile(targetFilePath, content);
     }
-  } catch (err){
+  } catch (err) {
     log.error('RenderError', err);
     throw err;
   }

--- a/packages/build-plugin-block/src/index.js
+++ b/packages/build-plugin-block/src/index.js
@@ -14,7 +14,7 @@ const formatPath = (outputPath) => {
 
 module.exports = (
   { context, log, registerTask, registerUserConfig, onGetWebpackConfig, onGetJestConfig },
-  userConfig
+  userConfig,
 ) => {
   const { usingTemplate, materialType } = userConfig || {};
   const { rootDir, command, pkg } = context;
@@ -28,7 +28,7 @@ module.exports = (
   // ejs 模板通过接下来的步骤渲染至 .tmp 文件夹。
   // 之后我们将 @/block 重定位到 .tmp 文件夹
   // 这样就引入了经过模拟数据渲染的代码。
-  function updateMockData(){
+  function updateMockData() {
     try {
       require.cache[mockDir] = undefined;
       mockData = require(mockDir);
@@ -41,8 +41,8 @@ module.exports = (
     updateMockData();
     ejsRender(sourceDir, tmpDir, mockData, log);
     if (mode === 'development') {
-      const templateWatcher = chokidar.watch(sourceDir, {ignoreInitial: true});
-      const mockWatcher = chokidar.watch(mockDir, {ignoreInitial: true});
+      const templateWatcher = chokidar.watch(sourceDir, { ignoreInitial: true });
+      const mockWatcher = chokidar.watch(mockDir, { ignoreInitial: true });
       templateWatcher.on('change', () => {
         log.info('FILE CHANGE');
         ejsRender(sourceDir, tmpDir, mockData, log);

--- a/packages/build-plugin-component-screenshot/src/index.js
+++ b/packages/build-plugin-component-screenshot/src/index.js
@@ -14,7 +14,7 @@ module.exports = (
   onHook('after.build.compile', async () => {
     debug('cloud', cloud);
     // cloud build support
-    if(!cloud && process.env.BUILD_ENV === 'cloud') {
+    if (!cloud && process.env.BUILD_ENV === 'cloud') {
       log.warn('current environment not support screenshot');
       return;
     }
@@ -33,7 +33,7 @@ module.exports = (
     debug('demos', demos);
     const selectors = demos.filter(item => /^.*\.md$/g.test(item)).map(item => item.replace(/\.md$/g, ''));
     debug('selectors', selectors);
-    if(!selectors.length){
+    if (!selectors.length) {
       return;
     }
     const snapshots = await screenshotWithLocalServer(serverPath, port, targetUrl, selectors, viewsPath);

--- a/packages/build-plugin-component-screenshot/src/screenshot/index.js
+++ b/packages/build-plugin-component-screenshot/src/screenshot/index.js
@@ -28,13 +28,13 @@ async function minifyImg(imgPath, outputDir) {
  * @param {array} selectors screenshot target CSS selector
  * @param {string} viewsPath output path
  */
-async function screenshot(url, selectors=[], viewsPath, timeout) {
+async function screenshot(url, selectors = [], viewsPath, timeout) {
   // a terminal spinner
   const spinner = ora('generating ...').start();
 
   try {
     const puppeteer = await getPuppeteer();
-    
+
     // start puppeteer
     const browser = await puppeteer.launch();
 
@@ -57,14 +57,14 @@ async function screenshot(url, selectors=[], viewsPath, timeout) {
     const res = await Promise.all(selectors.map(async item => {
       const output = `${viewsPath}/${item}.png`;
       const el = await page.$(`#${item}`);
-      await el.screenshot({ path:  output});
+      await el.screenshot({ path: output });
       await minifyImg(output, output);
       return `views/${item}.png`;
     }));
-    
+
     // close chromium
     await browser.close();
-    
+
     spinner.succeed(chalk.green('generating success!'));
     return res;
   } catch (err) {

--- a/packages/build-plugin-component/src/compiler/babel.js
+++ b/packages/build-plugin-component/src/compiler/babel.js
@@ -170,7 +170,7 @@ module.exports = function babelCompiler(
           ? [styleSatements, styleContent].filter(Boolean).join('\n')
           : '//empty file';
       fs.writeFileSync(stylePath, styleContent, 'utf-8');
-      log.info(`generate style.js to ${target}`);      
+      log.info(`generate style.js to ${target}`);
     }
   });
   // generate DTS for TS files

--- a/packages/build-plugin-component/src/compiler/depAnalyze.js
+++ b/packages/build-plugin-component/src/compiler/depAnalyze.js
@@ -12,7 +12,7 @@ const getPkgJSON = (cwd, module) => {
 
 function analyzePackage(pkg, basicComponents) {
   // get dependencies from pakage.json
-  const { dependencies = {}, devDependencies = {}, peerDependencies = {}  } = pkg;
+  const { dependencies = {}, devDependencies = {}, peerDependencies = {} } = pkg;
   const libraryNames = [];
   if (basicComponents) {
     Object.keys({ ...dependencies, ...devDependencies, ...peerDependencies }).forEach(depName => {

--- a/packages/build-plugin-component/src/compiler/dts.js
+++ b/packages/build-plugin-component/src/compiler/dts.js
@@ -34,7 +34,7 @@ module.exports = function dtsCompiler(compileInfo, log = console) {
   // Create a Program with an in-memory emit
   let createdFiles = {};
   const host = ts.createCompilerHost(options);
-  host.writeFile = (fileName, contents) => (createdFiles[fileName] = contents);
+  host.writeFile = (fileName, contents) => { createdFiles[fileName] = contents; };
 
   // Prepare and emit the d.ts files
   const program = ts.createProgram(needCompileList.map(({ sourceFile }) => sourceFile), options, host);
@@ -59,7 +59,7 @@ module.exports = function dtsCompiler(compileInfo, log = console) {
       fse.writeFileSync(targetPath, content, 'utf-8');
     }
   });
-  
+
   // release
   createdFiles = null;
 };

--- a/packages/build-plugin-component/src/configs/rax/getBaseWebpack.js
+++ b/packages/build-plugin-component/src/configs/rax/getBaseWebpack.js
@@ -26,7 +26,7 @@ module.exports = (context, options) => {
   config.output.publicPath('/');
 
   config.externals([
-    function(ctx, request, callback) {
+    function (ctx, request, callback) {
       if (request.indexOf('@weex-module') !== -1) {
         return callback(null, `commonjs ${request}`);
       }
@@ -58,7 +58,7 @@ module.exports = (context, options) => {
     .loader(require.resolve('ts-loader'));
 
   if (options.enablePlatformLoader && target) {
-    ['jsx','tsx'].forEach((rule) => {
+    ['jsx', 'tsx'].forEach((rule) => {
       config.module.rule(rule)
         .use('platform')
         .loader(require.resolve('rax-compile-config/src/platformLoader'))

--- a/packages/build-plugin-component/src/configs/rax/getDemoConfig.js
+++ b/packages/build-plugin-component/src/configs/rax/getDemoConfig.js
@@ -31,7 +31,7 @@ module.exports = (context, options) => {
       config
         .entry(`demo/${entryKey}`)
         .add(entries[entryKey]);
-  
+
       config.plugin(`html4${entryKey}`).use(HtmlWebpackPlugin, [
         {
           inject: true,

--- a/packages/build-plugin-component/src/configs/rax/getDistConfig.js
+++ b/packages/build-plugin-component/src/configs/rax/getDistConfig.js
@@ -13,7 +13,7 @@ module.exports = (context, options) => {
     .add(path.resolve(rootDir, 'src/index'));
 
   config.externals([
-    function(ctx, request, callback) {
+    function (ctx, request, callback) {
       if (request.indexOf('@weex-module') !== -1) {
         return callback(null, `commonjs ${request}`);
       }

--- a/packages/build-plugin-component/src/configs/rax/getES6Config.js
+++ b/packages/build-plugin-component/src/configs/rax/getES6Config.js
@@ -1,8 +1,7 @@
-const _ = require('lodash');
 const getDistConfig = require('./getDistConfig');
 
 module.exports = (context, options) => {
-  const config = getDistConfig(context, {...options, isES6: true});
+  const config = getDistConfig(context, { ...options, isES6: true });
   config.output.filename('index-es6.js');
   return config;
 };

--- a/packages/build-plugin-component/src/configs/rax/getUMDConfig.js
+++ b/packages/build-plugin-component/src/configs/rax/getUMDConfig.js
@@ -20,7 +20,7 @@ module.exports = (context, options) => {
     .libraryTarget(libraryTarget);
   if (libraryExport) {
     config.output.libraryExport(libraryExport);
-  } 
+  }
   config.output.filename(filename);
   return config;
 };

--- a/packages/build-plugin-component/src/configs/rax/miniapp/getBase.js
+++ b/packages/build-plugin-component/src/configs/rax/miniapp/getBase.js
@@ -6,13 +6,13 @@ const getWebpackBase = require('../getBaseWebpack');
 const getOutputPath = require('./getOutputPath');
 const { MINIAPP } = require('../../../constants');
 
-const parseTarget = (target) => target === MINIAPP ? 'ali-miniapp' : target;
+const parseTarget = (target) => (target === MINIAPP ? 'ali-miniapp' : target);
 module.exports = (context, target, options = {}, onGetWebpackConfig) => {
   const { rootDir, command } = context;
   const { distDir = '' } = options[target] || {};
   const outputPath = getOutputPath(context, { target, distDir });
   const config = getWebpackBase(context, {
-    disableRegenerator: true
+    disableRegenerator: true,
   });
   let entryPath = './src/index';
   if (command === 'start') {
@@ -26,13 +26,13 @@ module.exports = (context, target, options = {}, onGetWebpackConfig) => {
   const miniappOutput = path.join(rootDir, 'build', parseTarget(target));
   fse.ensureDirSync(miniappOutput);
   fse.copySync(path.join(__dirname, `../../../template/miniapp/${parseTarget(target)}`), miniappOutput);
-  
+
   setComponentConfig(config, options[target], {
     onGetWebpackConfig,
     context,
     entryPath,
     outputPath,
-    target
+    target,
   });
 
   return config;

--- a/packages/build-plugin-component/src/configs/rax/node/dev.js
+++ b/packages/build-plugin-component/src/configs/rax/node/dev.js
@@ -16,7 +16,7 @@ function exec(code, filename, filePath) {
 module.exports = (config, context, options) => {
   const { rootDir } = context;
   const { serverBundles } = options;
-  
+
   Object.keys(serverBundles).forEach((entryKey) => {
     config
       .entry(`${entryKey}-ssr`)
@@ -55,7 +55,7 @@ module.exports = (config, context, options) => {
     const outputFs = devServer.compiler.compilers[0].outputFileSystem;
 
     Object.keys(serverBundles).forEach((entryKey) => {
-      app.get(`/ssr/${entryKey}`, async function(req, res) {
+      app.get(`/ssr/${entryKey}`, async (req, res) => {
         const query = req.query || {};
         // disable hydarte for debug http://localhost:9999/ssr/index?hydrate=false
         const hydrate = query.hydrate !== 'false';

--- a/packages/build-plugin-component/src/configs/rax/node/ignoreLoader.js
+++ b/packages/build-plugin-component/src/configs/rax/node/ignoreLoader.js
@@ -1,4 +1,4 @@
-module.exports = function() {
+module.exports = function () {
   this.cacheable && this.cacheable();
   return '';
 };

--- a/packages/build-plugin-component/src/configs/rax/userConfig.js
+++ b/packages/build-plugin-component/src/configs/rax/userConfig.js
@@ -1,6 +1,6 @@
 const CONFIG = {
   process: false,
-  global: false
+  global: false,
 };
 
 module.exports = [

--- a/packages/build-plugin-component/src/configs/rax/web/dev.js
+++ b/packages/build-plugin-component/src/configs/rax/web/dev.js
@@ -5,7 +5,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const setCSSRule = require('../../../utils/setCSSRule');
 
 module.exports = (config, context, options) => {
-  const { taskName } = context;
   const { entries } = options;
 
   Object.keys(entries).forEach((entryKey) => {

--- a/packages/build-plugin-component/src/configs/react/base.js
+++ b/packages/build-plugin-component/src/configs/react/base.js
@@ -15,7 +15,7 @@ module.exports = (config, { pkg, rootDir, entry }) => {
       filename: 'index.html',
     },
   ]);
-  
+
   config.resolve.modules
     .add('node_modules')
     .add(path.join(rootDir, 'node_modules'))

--- a/packages/build-plugin-component/src/index.js
+++ b/packages/build-plugin-component/src/index.js
@@ -8,4 +8,4 @@ module.exports = (api) => {
     // eslint-disable-next-line
     require(`./${componentType}`)(api);
   }
-}
+};

--- a/packages/build-plugin-component/src/rax.js
+++ b/packages/build-plugin-component/src/rax.js
@@ -36,7 +36,7 @@ module.exports = ({ registerTask, registerUserConfig, context, onHook, registerC
   // register user config
   registerUserConfig(defaultUserConfig.concat(raxUserConfig));
   // disable demo when watch dist
-  
+
   let entries = {};
   let serverBundles = {};
   let demos = [];
@@ -65,7 +65,7 @@ module.exports = ({ registerTask, registerUserConfig, context, onHook, registerC
         ignoreInitial: false,
         interval: 200,
       });
-      demoWatcher.on('all', () => {  
+      demoWatcher.on('all', () => {
         // re-generate entry files when demo changes
         raxBundles = getRaxBundles();
       });
@@ -87,7 +87,7 @@ module.exports = ({ registerTask, registerUserConfig, context, onHook, registerC
         // eslint-disable-next-line
         const configDev = require(`./configs/rax/${target}/dev`);
         const defaultConfig = getBaseWebpack(context, options);
-        configDev(defaultConfig, context, {...options, entries, serverBundles } );
+        configDev(defaultConfig, context, { ...options, entries, serverBundles });
         registerTask(`component-demo-${target}`, defaultConfig);
       } else if ([MINIAPP, WECHAT_MINIPROGRAM].includes(target)) {
         options[target] = options[target] || {};
@@ -137,14 +137,14 @@ module.exports = ({ registerTask, registerUserConfig, context, onHook, registerC
       config.devServer.hot(false);
     });
   }
-  
-  onHook('after.build.compile', async(args) => {
+
+  onHook('after.build.compile', async (args) => {
     buildCompileLog(args, targets, rootDir, userConfig);
     if (!skipDemo) {
       await modifyPkgHomePage(pkg, rootDir);
     }
   });
-  onHook('after.start.compile', async(args) => {
+  onHook('after.start.compile', async (args) => {
     const devUrl = args.url;
     devCompileLog(args, devUrl, targets, entries, rootDir, { ...userConfig, watchDist });
   });
@@ -161,7 +161,7 @@ module.exports = ({ registerTask, registerUserConfig, context, onHook, registerC
       };
     });
   }
-}
+};
 
 /**
  * Add miniapp target param to match jsx2mp-loader config

--- a/packages/build-plugin-component/src/react.js
+++ b/packages/build-plugin-component/src/react.js
@@ -21,7 +21,7 @@ const reactUserConfig = require('./configs/react/userConfig');
 const babelCompiler = require('./compiler/babel');
 
 module.exports = (
-  { context, registerTask, registerCliOption, registerUserConfig, onGetWebpackConfig, onHook, log, onGetJestConfig }
+  { context, registerTask, registerCliOption, registerUserConfig, onGetWebpackConfig, onHook, log, onGetJestConfig },
 ) => {
   const { command, rootDir, pkg, commandArgs, userConfig } = context;
   const { plugins, ...compileOptions } = userConfig;
@@ -60,7 +60,7 @@ module.exports = (
               ...demo,
               filePath: formatPathForWin(demo.filePath),
               demoKey,
-            }
+            };
           }),
         });
       });
@@ -82,7 +82,7 @@ module.exports = (
       // wirte demo content
       fs.writeFileSync(demoDataPath, `const data = ${JSON.stringify(demoData)};export default data;`);
       params.entry = { index: entryPath };
-    }
+    };
 
     generateDemoEntry();
 

--- a/packages/build-plugin-component/src/utils/getCompileBabel.js
+++ b/packages/build-plugin-component/src/utils/getCompileBabel.js
@@ -39,7 +39,7 @@ module.exports = (options = {}, { babelPlugins, babelOptions, rootDir }) => {
       return [presetPath, { modules, loose: true, ...(modifyOptions || {}) }];
     }
     if (presetOptions && modifyOptions) {
-      return [presetPath, {...presetOptions, ...modifyOptions}];
+      return [presetPath, { ...presetOptions, ...modifyOptions }];
     }
     return preset;
   });

--- a/packages/build-plugin-component/src/utils/getReadme.js
+++ b/packages/build-plugin-component/src/utils/getReadme.js
@@ -8,7 +8,7 @@ module.exports = function getReadme(cwd, markdownParser, log) {
   try {
     const markdown = fs.readFileSync(filePath, 'utf-8');
     result = markdownParser(markdown);
-  } catch(err) {
+  } catch (err) {
     log.warn('读取/解析 README.md 错误');
     console.error(err);
   }

--- a/packages/build-plugin-component/src/utils/getUMDWebpack.js
+++ b/packages/build-plugin-component/src/utils/getUMDWebpack.js
@@ -48,7 +48,7 @@ module.exports = ({ context, compileOptions, extNames, hasMain }) => {
   // file name
   const filename = compileOptions.filename || library;
   const jsPath = path.resolve(rootDir, `src/index${jsExt}`);
-  
+
   config.context(rootDir);
 
   // - set entry
@@ -90,6 +90,6 @@ module.exports = ({ context, compileOptions, extNames, hasMain }) => {
     // disable minify code
     config.optimization.minimize(minify);
   }
-  
+
   return config;
 };

--- a/packages/build-plugin-component/src/utils/markdownHelper.js
+++ b/packages/build-plugin-component/src/utils/markdownHelper.js
@@ -19,7 +19,7 @@ const codeTemplate = `
   </div>
 `;
 
-renderer.code = function(code, lang) {
+renderer.code = function (code, lang) {
   // lang = ''
   if (!lang) {
     lang = 'jsx';
@@ -35,14 +35,14 @@ renderer.code = function(code, lang) {
   return util.format(codeTemplate, lang, lang, html);
 };
 
-renderer.heading = function(text, level) {
+renderer.heading = function (text, level) {
   let escapedText = text.replace(/\s+/g, '-');
   escapedText = escapedText.toLowerCase();
   escapedText = escapedText.replace(/^-+?|-+?$/, '');
   return `<h${level}>${text}<a id="user-content-${escapedText}" name="${escapedText}" class="anchor" aria-hidden="true" href="#${escapedText}"><span class="octicon octicon-link"></span></a></h${level}>`;
 };
 
-renderer.link = function(href, title, text) {
+renderer.link = function (href, title, text) {
   if (href.indexOf('http') === 0) {
     return `<a href="${href}" title="${title}">${text}</a>`;
   }

--- a/packages/build-plugin-component/src/utils/modifyPkgHomePage.js
+++ b/packages/build-plugin-component/src/utils/modifyPkgHomePage.js
@@ -14,9 +14,9 @@ module.exports = async (pkg, rootDir) => {
   if (!unpkgHost) {
     try {
       // 2. 物料集合根目录的 pkg.materialConfig
-      const materialPkgData =  await fse.readJSON(path.resolve(rootDir, '../../package.json'));
+      const materialPkgData = await fse.readJSON(path.resolve(rootDir, '../../package.json'));
       unpkgHost = materialPkgData.materialConfig && materialPkgData.materialConfig.unpkgHost;
-    } catch(err) {
+    } catch (err) {
       // ignore error
     }
 
@@ -24,9 +24,9 @@ module.exports = async (pkg, rootDir) => {
       try {
         // 3. iceworks cli config
         const CONFIG_PATH = path.join(userHome || __dirname, '.iceworks/cli-config.json');
-        const configData =  await fse.readJSON(CONFIG_PATH);
+        const configData = await fse.readJSON(CONFIG_PATH);
         unpkgHost = configData && configData.unpkgHost;
-      } catch(err) {
+      } catch (err) {
         // ignore error
       }
 

--- a/packages/build-plugin-component/src/utils/raxBuildCompileLog.js
+++ b/packages/build-plugin-component/src/utils/raxBuildCompileLog.js
@@ -5,7 +5,7 @@ const { platformMap } = require('miniapp-builder-shared');
 const consoleClear = require('console-clear');
 const { WEB, WEEX } = require('../constants');
 
-function raxBuildCompileLog({err, stats}, targets, rootDir, options) {
+function raxBuildCompileLog({ err, stats }, targets, rootDir, options) {
   consoleClear(true);
 
   if (!handleWebpackErr(err, stats)) {
@@ -26,7 +26,7 @@ function raxBuildCompileLog({err, stats}, targets, rootDir, options) {
   Object.entries(platformMap).forEach(([platform, config]) => {
     if (targets.includes(platform)) {
       console.log(chalk.green(`[${config.name}] Component lib at:`));
-      const distDir = options[platform] && options[platform].distDir || `lib/${platform}`;
+      const distDir = (options[platform] && options[platform].distDir) || `lib/${platform}`;
       console.log('   ', chalk.underline.white(path.resolve(rootDir, distDir)));
       console.log();
     }

--- a/packages/build-plugin-component/src/utils/raxDevCompileLog.js
+++ b/packages/build-plugin-component/src/utils/raxDevCompileLog.js
@@ -22,7 +22,7 @@ function devCompileLog(devCompleted, devUrl, targets, entries, rootDir, options)
     console.log(chalk.green('[Dist] Development pages:'));
     ['index', 'index-es6', 'index-weex'].forEach((distBundle) => {
       console.log('   ', chalk.underline.white(`${devUrl}${distBundle}.js`));
-    })
+    });
     return;
   }
 
@@ -50,7 +50,7 @@ function devCompileLog(devCompleted, devUrl, targets, entries, rootDir, options)
 
     Object.keys(entries).forEach((entry) => {
       // Use Weex App to scan ip address (mobile phone can't visit localhost).
-      const weexUrl = `${devUrl}weex/${entry}.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function(match) {
+      const weexUrl = `${devUrl}weex/${entry}.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, (match) => {
         // Called when matched
         try {
           return `http://${ip.address()}`;

--- a/packages/build-plugin-component/src/utils/setCSSRule.js
+++ b/packages/build-plugin-component/src/utils/setCSSRule.js
@@ -79,4 +79,4 @@ module.exports = (config, useStylesheetLoader) => {
       .use('sass-loader')
       .loader(require.resolve('sass-loader'));
   }
-}
+};

--- a/packages/build-plugin-component/src/webpackPlugins/weex/WeexFrameworkBannerPlugin.js
+++ b/packages/build-plugin-component/src/webpackPlugins/weex/WeexFrameworkBannerPlugin.js
@@ -24,7 +24,7 @@ class WeexFrameworkBannerPlugin {
               continue; // eslint-disable-line
             }
 
-            chunk.files.forEach(function(file) {
+            chunk.files.forEach((file) => {
               compilation.assets[file] = new ConcatSource(
                 frameworkComment,
                 '\n',
@@ -38,8 +38,8 @@ class WeexFrameworkBannerPlugin {
       compiler.plugin('compilation', (compilation) => {
         // uglify-webpack-plugin will remove javascript's comments in
         // optimize-chunk-assets, add frameworkComment after that.
-        compilation.plugin('after-optimize-chunk-assets', function(chunks) {
-          chunks.forEach(function(chunk) {
+        compilation.plugin('after-optimize-chunk-assets', (chunks) => {
+          chunks.forEach((chunk) => {
             // Entry only
             try {
               // In webpack2 chunk.initial was removed. Use isInitial()
@@ -48,7 +48,7 @@ class WeexFrameworkBannerPlugin {
               if (!chunk.isInitial()) return;
             }
 
-            chunk.files.forEach(function(file) {
+            chunk.files.forEach((file) => {
               compilation.assets[file] = new ConcatSource(
                 frameworkComment,
                 '\n',

--- a/packages/build-plugin-fusion-material/index.js
+++ b/packages/build-plugin-fusion-material/index.js
@@ -20,13 +20,13 @@ module.exports = ({
   registerCliOption,
 }) => {
   // modify default outputAssetsPath
-  modifyUserConfig('outputAssetsPath', { js: '', css: ''});
+  modifyUserConfig('outputAssetsPath', { js: '', css: '' });
 
   // 仅在执行 tnpm run build --design (实际在区块上大多数是 tnpm run build -- --design)时生效
   // 开始为生成的 build/views/ 文件下的html文件内容，添加 data-fusioncool 信息
   registerCliOption({
     name: 'design', // 注册的 cli 参数名称，
-    commands: ['build'],  // 支持的命令，如果为空默认任何命令都将执行注册方法
+    commands: ['build'], // 支持的命令，如果为空默认任何命令都将执行注册方法
     configWebpack: (config) => {
       config.module
         .rule('fusion-cool-loader')
@@ -56,8 +56,7 @@ module.exports = ({
         htmlOutput: './build/views/block_view1.html',
       });
       updatePackageJson(packageJsonPath, 'blockConfig', ['build/views/block_view1.html'], ['build/views/block_view1.png']);
-    }
-    else if (pkg.scaffoldConfig && pkg.scaffoldConfig.views) {
+    } else if (pkg.scaffoldConfig && pkg.scaffoldConfig.views) {
       // scaffold type
       for (let i = 0; i < pkg.scaffoldConfig.views.length; i++) {
         // eslint-disable-next-line no-await-in-loop

--- a/packages/build-plugin-fusion-material/utils/createServer.js
+++ b/packages/build-plugin-fusion-material/utils/createServer.js
@@ -1,4 +1,4 @@
-  
+
 const http = require('http');
 const fs = require('fs');
 const url = require('url');

--- a/packages/build-plugin-fusion-material/utils/fusionCoolInfoLoader.js
+++ b/packages/build-plugin-fusion-material/utils/fusionCoolInfoLoader.js
@@ -42,7 +42,7 @@ module.exports = function fusionCoolInfoLoader(code) {
         let current;
 
         // 如果是 cosnt FormItem = Form.Item 这种
-        while(t.isVariableDeclaration(parent)) {
+        while (t.isVariableDeclaration(parent)) {
           current = parent.declarations[0].init;
           if (t.isIdentifier(current)) {
             currenName = current.name;

--- a/packages/generate-material/src/ejsRenderDir.ts
+++ b/packages/generate-material/src/ejsRenderDir.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as glob from 'glob';
 import * as ejs from 'ejs';
 import * as fse from 'fs-extra';
-import { ITemplateOptions } from './index';
+import { ITemplateOptions } from './types';
 
 export default async function (templateDir: string, destDir: string, options: ITemplateOptions): Promise<void> {
   const templateTmpDir = path.join(destDir, '.ejs-tmp');
@@ -27,15 +27,15 @@ export default async function (templateDir: string, destDir: string, options: IT
           files.map((file) => {
             const filepath = path.join(templateTmpDir, file);
             return renderFile(filepath, options);
-          })
+          }),
         )
           .then(() => {
             resolve();
           })
-          .catch((err) => {
-            reject(err);
+          .catch((error) => {
+            reject(error);
           });
-      }
+      },
     );
   });
 

--- a/packages/generate-material/src/formatProject.ts
+++ b/packages/generate-material/src/formatProject.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import { isAliNpm } from 'ice-npm-utils';
-import { ITemplateOptions } from './index';
+import { ITemplateOptions } from './types';
 
 interface IOptions {
   rootDir: string;

--- a/packages/generate-material/src/index.ts
+++ b/packages/generate-material/src/index.ts
@@ -3,37 +3,13 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as camelcase from 'camelcase';
 import { getNpmTarball, getAndExtractTarball } from 'ice-npm-utils';
-
+import { IOptions, ITemplateOptions } from './types';
 import ejsRenderDir from './ejsRenderDir';
 import formatProject from './formatProject';
 
 /**
  * init component by template
  */
-export interface ITemplateOptions {
-  npmName: string; // @icedesign/ice-label
-  name?: string; // ice-label (english and variable)
-  kebabCaseName?: string; // ice-label
-  npmScope?: string; // @icedesign
-  title?: string; //
-  description?: string;
-  className?: string;
-  version?: string;
-  category?: string;
-  // web, miniapp...
-  projectTargets?: string[];
-  adaptor?: boolean;
-}
-
-export interface IOptions {
-  rootDir: string;
-  materialTemplateDir: string;
-  templateOptions: ITemplateOptions;
-  enablePegasus?: boolean;
-  enableDefPublish?: boolean;
-  materialType: 'component' | 'block' | 'scaffold';
-}
-
 export async function generateMaterial({
   rootDir,
   materialTemplateDir,
@@ -111,7 +87,7 @@ export async function downloadMaterialTemplate(dir: string, template: string, re
           filename = 'package.json.ejs';
         }
         return filename;
-      }
+      },
     );
     spinner.succeed('download npm tarball successfully.');
   }

--- a/packages/generate-material/src/types.ts
+++ b/packages/generate-material/src/types.ts
@@ -1,0 +1,23 @@
+export interface ITemplateOptions {
+  npmName: string; // @icedesign/ice-label
+  name?: string; // ice-label (english and variable)
+  kebabCaseName?: string; // ice-label
+  npmScope?: string; // @icedesign
+  title?: string; //
+  description?: string;
+  className?: string;
+  version?: string;
+  category?: string;
+  // web, miniapp...
+  projectTargets?: string[];
+  adaptor?: boolean;
+}
+
+export interface IOptions {
+  rootDir: string;
+  materialTemplateDir: string;
+  templateOptions: ITemplateOptions;
+  enablePegasus?: boolean;
+  enableDefPublish?: boolean;
+  materialType: 'component' | 'block' | 'scaffold';
+}

--- a/packages/generate-project/src/ejsRenderDir.ts
+++ b/packages/generate-project/src/ejsRenderDir.ts
@@ -22,15 +22,15 @@ export default async function (dir: string, options: any): Promise<void> {
           files.map((file) => {
             const filepath = path.join(dir, file);
             return renderFile(filepath, options);
-          })
+          }),
         )
           .then(() => {
             resolve();
           })
-          .catch((err) => {
-            reject(err);
+          .catch((error) => {
+            reject(error);
           });
-      }
+      },
     );
   });
 }

--- a/packages/generate-project/src/index.ts
+++ b/packages/generate-project/src/index.ts
@@ -19,7 +19,7 @@ export async function downloadAndGenerateProject(
   version?: string,
   registry?: string,
   projectName?: string,
-  ejsOptions?: IEjsOptions
+  ejsOptions?: IEjsOptions,
 ): Promise<void> {
   registry = registry || (await getNpmRegistry(npmName));
 
@@ -51,7 +51,7 @@ export async function downloadAndGenerateProject(
     (state) => {
       spinner.text = `download npm tarball progress: ${Math.floor(state.percent * 100)}%`;
     },
-    formatFilename
+    formatFilename,
   );
   spinner.succeed('download npm tarball successfully.');
 

--- a/packages/ice-npm-utils/src/index.ts
+++ b/packages/ice-npm-utils/src/index.ts
@@ -35,6 +35,7 @@ function getNpmTarball(npm: string, version?: string, registry?: string): Promis
 function getAndExtractTarball(
   destDir: string,
   tarball: string,
+  // eslint-disable-next-line
   progressFunc = (state) => {},
   formatFilename = (filename: string): string => {
     // 为了兼容
@@ -43,7 +44,7 @@ function getAndExtractTarball(
     } else {
       return filename.replace(/^_/, '.');
     }
-  }
+  },
 ): Promise<string[]> {
   return new Promise((resolve, reject) => {
     const allFiles = [];
@@ -54,7 +55,7 @@ function getAndExtractTarball(
       request({
         url: tarball,
         timeout: 10000,
-      })
+      }),
     )
       .on('progress', progressFunc)
       .on('error', reject)
@@ -87,7 +88,7 @@ function getAndExtractTarball(
               .pipe(fs.createWriteStream(destPath))
               .on('finish', () => streamResolve())
               .on('close', () => streamResolve()); // resolve when file is empty in node v8
-          })
+          }),
         );
       })
       .on('end', () => {
@@ -223,7 +224,7 @@ function checkAliInternal(): Promise<boolean> {
     timeout: 3 * 1000,
     resolveWithFullResponse: true,
   })
-    .catch((err) => {
+    .catch(() => {
       return false;
     })
     .then((response) => {
@@ -240,7 +241,8 @@ async function readPackageJSON(projectPath: string) {
     // eslint-disable-next-line quotes
     throw new Error("Project's package.json file not found in local environment");
   }
-  return await fsExtra.readJson(packagePath);
+  const content = await fsExtra.readJson(packagePath);
+  return content;
 }
 
 /**

--- a/packages/ice-screenshot/bin/index.js
+++ b/packages/ice-screenshot/bin/index.js
@@ -28,7 +28,7 @@ async function exec() {
       .option('-u, --url <url>', 'The target url or path to local server')
       .option(
         '-l, --local [local]',
-        'Set up a local server in [local] directory and take screenshot, defaults set up in `./`'
+        'Set up a local server in [local] directory and take screenshot, defaults set up in `./`',
       )
       .option('-s, --selector <selector>', 'Select a element through CSS selector')
       .option('-t, --timeout <timeout>', 'screenshot with a delay')
@@ -148,8 +148,8 @@ async function screenshot(url, selector, output, timeout) {
       console.log(chalk.white('\n  npm uninstall puppeteer -g'));
       console.log(
         chalk.white(
-          '\n  PUPPETEER_DOWNLOAD_HOST=https://storage.googleapis.com.cnpmjs.org npm i puppeteer -g --registry=https://registry.npm.taobao.org'
-        )
+          '\n  PUPPETEER_DOWNLOAD_HOST=https://storage.googleapis.com.cnpmjs.org npm i puppeteer -g --registry=https://registry.npm.taobao.org',
+        ),
       );
       console.log(chalk.white('\n  screenshot -u http://www.example.com\n'));
     } else {

--- a/packages/ice-screenshot/utils/getPuppeteer.js
+++ b/packages/ice-screenshot/utils/getPuppeteer.js
@@ -37,7 +37,7 @@ module.exports = async function getPuppeteer() {
           const result = spawn.sync(
             'npm',
             ['install', 'puppeteer@1.x', '-g', '--registry', 'https://registry.npm.taobao.org'],
-            { stdio: 'inherit' }
+            { stdio: 'inherit' },
           );
           spawn.sync('npm', ['config', 'delete', 'puppeteer_download_host']);
 
@@ -47,8 +47,8 @@ module.exports = async function getPuppeteer() {
             console.log(chalk.white('\n  npm uninstall puppeteer -g'));
             console.log(
               chalk.white(
-                '\n  PUPPETEER_DOWNLOAD_HOST=https://storage.googleapis.com.cnpmjs.org npm i puppeteer -g --registry=https://registry.npm.taobao.org'
-              )
+                '\n  PUPPETEER_DOWNLOAD_HOST=https://storage.googleapis.com.cnpmjs.org npm i puppeteer -g --registry=https://registry.npm.taobao.org',
+              ),
             );
             console.log(chalk.white('\n  screenshot -u http://www.example.com\n'));
             process.exit(1);

--- a/packages/iceworks-cli/bin/iceworks.js
+++ b/packages/iceworks-cli/bin/iceworks.js
@@ -26,7 +26,7 @@ program
     console.log('');
     console.log('  $ iceworks start');
   })
-  .action(async (version, cmd) => {
+  .action(async () => {
     try {
       // eslint-disable-next-line global-require
       await require('../lib/command/start').default();
@@ -258,9 +258,9 @@ async function checkIceworksVersion() {
     console.log(
       chalk.yellow(
         `A newer version of iceworks-cli is available(CHANGELOG: ${chalk.blue(
-          'https://github.com/ice-lab/iceworks-cli/releases'
-        )})`
-      )
+          'https://github.com/ice-lab/iceworks-cli/releases',
+        )})`,
+      ),
     );
     console.log(`  latest:     + ${chalk.yellow(latestVersion)}`);
     console.log(`  installed:  + ${chalk.red(packageVersion)} \n`);

--- a/packages/iceworks-cli/src/command/add/addBlockToProject.ts
+++ b/packages/iceworks-cli/src/command/add/addBlockToProject.ts
@@ -20,7 +20,7 @@ export default async (options, destDir) => {
     const blockDirPath = await addBlock(options, destDir, tempDir);
     await fse.remove(tempDir);
     log.info('add block success, you can import and use block in your page code', blockDirPath);
-  } catch(err) {
+  } catch (err) {
     fse.removeSync(tempDir);
     throw err;
   }

--- a/packages/iceworks-cli/src/command/config/index.ts
+++ b/packages/iceworks-cli/src/command/config/index.ts
@@ -6,7 +6,7 @@ interface IConfig {
   value?: any;
 }
 
-export default async function(options: IConfig): Promise<any> {
+export default async function (options: IConfig): Promise<any> {
   const { type, key, value } = options;
 
   if (!type || type === 'list') {
@@ -23,4 +23,4 @@ export default async function(options: IConfig): Promise<any> {
   } else {
     throw new Error('Invalid options');
   }
-};
+}

--- a/packages/iceworks-cli/src/command/generate/generateMaterialData.ts
+++ b/packages/iceworks-cli/src/command/generate/generateMaterialData.ts
@@ -30,7 +30,7 @@ export default async function generateMaterialData(pkgPath, materialType, materi
   const screenshots = materialItemConfig.screenshots || (screenshot && [screenshot]);
   const homepage = pkg.homepage || `${unpkgHost}/${npmName}@${pkg.version}/build/index.html`;
 
-  const {categories: originCategories, category: originCategory} = materialItemConfig;
+  const { categories: originCategories, category: originCategory } = materialItemConfig;
   // categories 字段：即将废弃，但是展示端还依赖该字段，因此短期内不能删除，同时需要兼容新的物料无 categories 字段
   const categories = originCategories || (originCategory ? [originCategory] : []);
   // category 字段：兼容老的物料无 category 字段
@@ -74,7 +74,7 @@ export default async function generateMaterialData(pkgPath, materialType, materi
   }
 
   return { materialData, materialType };
-};
+}
 
 /**
  * 检测 NPM 包是否已发送，并返回包的发布时间

--- a/packages/iceworks-cli/src/command/generate/index.ts
+++ b/packages/iceworks-cli/src/command/generate/index.ts
@@ -31,7 +31,7 @@ export default async function (options) {
   const [blocks, components, scaffolds, pages] = await Promise.all(
     ['block', 'component', 'scaffold', 'page'].map((item) => {
       return globMaterials(cwd, item);
-    })
+    }),
   );
   const allMaterials = [].concat(blocks).concat(components).concat(scaffolds).concat(pages);
 
@@ -55,7 +55,7 @@ export default async function (options) {
       },
       {
         concurrency,
-      }
+      },
     );
     spinner.succeed(`materials data generate successfully，start write to ${DB_PATH}...`);
   } catch (err) {
@@ -125,7 +125,7 @@ function globMaterials(materialDir, materialType) {
           });
           resolve(data);
         }
-      }
+      },
     );
   });
 }

--- a/packages/iceworks-cli/src/command/init/addSingleMaterial.ts
+++ b/packages/iceworks-cli/src/command/init/addSingleMaterial.ts
@@ -36,6 +36,7 @@ export default async function ({
   log.verbose('addSingleMaterial args', materialDir, cwd, useDefaultOptions, npmScope, materialType);
 
   const questions = getQuestions(npmScope, cwd)[materialType];
+  // eslint-disable-next-line
   let options: ITemplateOptions = {} as ITemplateOptions;
 
   if (useDefaultOptions || process.env.NODE_ENV === 'unittest') {
@@ -71,9 +72,9 @@ export default async function ({
     await Promise.all(
       ['.eslintignore', '.eslintrc.js', '.stylelintignore', '.stylelintrc.js', '.editorconfig', '.gitignore'].map(
         (filename) => {
-          return fse.remove(path.join(targetPath, filename)).catch((err) => {});
-        }
-      )
+          return fse.remove(path.join(targetPath, filename)).catch(() => { });
+        },
+      ),
     );
   }
 }

--- a/packages/iceworks-cli/src/command/init/ejsRenderDir.ts
+++ b/packages/iceworks-cli/src/command/init/ejsRenderDir.ts
@@ -3,7 +3,7 @@ import * as glob from 'glob';
 import * as ejs from 'ejs';
 import * as fse from 'fs-extra';
 
-export default async function(dir: string, options: any): Promise<void> {
+export default async function (dir: string, options: any): Promise<void> {
   return new Promise((resolve, reject) => {
     glob('**', {
       cwd: dir,
@@ -20,12 +20,12 @@ export default async function(dir: string, options: any): Promise<void> {
         return renderFile(filepath, options);
       })).then(() => {
         resolve();
-      }).catch((err) => {
-        reject(err);
+      }).catch((error) => {
+        reject(error);
       });
     });
   });
-};
+}
 
 function renderFile(filepath: string, options: any): Promise<string> {
   let filename = path.basename(filepath);

--- a/packages/iceworks-cli/src/command/init/generateNpmName.ts
+++ b/packages/iceworks-cli/src/command/init/generateNpmName.ts
@@ -1,7 +1,7 @@
 import * as decamelize from 'decamelize';
 
-export default function(name: string, npmScope?: string): string {
+export default function (name: string, npmScope?: string): string {
   // WebkitTransform -> webkit-transform
   name = decamelize(name, '-');
   return npmScope ? `${npmScope}/${name}` : name;
-};
+}

--- a/packages/iceworks-cli/src/command/init/index.ts
+++ b/packages/iceworks-cli/src/command/init/index.ts
@@ -8,9 +8,9 @@ interface IOptions {
   rootDir?: string;
   npmName?: string;
   type?: string;
-};
+}
 
-export default async function(options: IOptions = {}): Promise<void> {
+export default async function (options: IOptions = {}): Promise<void> {
   const cwd = options.rootDir || process.cwd();
   let { npmName, type } = options;
   log.verbose('iceworks init options', options as string);
@@ -40,7 +40,7 @@ export default async function(options: IOptions = {}): Promise<void> {
     projectType: type,
     template: npmName,
   });
-};
+}
 
 /**
  * 选择初始项目类型

--- a/packages/iceworks-cli/src/command/init/initMaterialAndComponent.ts
+++ b/packages/iceworks-cli/src/command/init/initMaterialAndComponent.ts
@@ -30,7 +30,7 @@ interface IOptions {
   template: string;
 }
 
-export default async function({
+export default async function ({
   cwd, projectType, template,
 }: IOptions): Promise<void> {
   log.verbose('initMaterialAndComponent', projectType, template);
@@ -50,7 +50,9 @@ export default async function({
     const tempRootFilesDir = path.join(tempMaterialDir, 'temp');
     await fse.copy(templatePath, tempRootFilesDir);
     await ejsRenderDir(tempRootFilesDir, {
-      npmName, description, template,
+      npmName,
+      description,
+      template,
       version: '0.1.0',
       materialConfig: templatePkg.materialConfig,
     });
@@ -113,7 +115,7 @@ export default async function({
 
   // remove temp dir
   await fse.remove(tempMaterialDir);
-};
+}
 
 
 interface IResult {

--- a/packages/iceworks-cli/src/command/start/index.ts
+++ b/packages/iceworks-cli/src/command/start/index.ts
@@ -1,6 +1,6 @@
 import log from '../../utils/log';
 
-export default async function start(options) {
+export default async function start() {
   console.log('');
   log.warn('', 'Please use Iceworks VS Code plugins: https://ice.work/docs/iceworks/about');
   console.log('');

--- a/packages/iceworks-cli/src/command/sync/fusionSDK.ts
+++ b/packages/iceworks-cli/src/command/sync/fusionSDK.ts
@@ -1,6 +1,6 @@
 import * as inquirer from 'inquirer';
 import axios, { AxiosRequestConfig } from 'axios';
-import * as ora from 'ora'
+import * as ora from 'ora';
 import * as _ from 'lodash';
 import * as chalk from 'chalk';
 import log from '../../utils/log';
@@ -63,7 +63,7 @@ export default class FusionSDK {
       url: `${this.fusionHost}/api/v1/mysites`,
       headers: {
         'x-auth-token': token,
-      }
+      },
     };
 
     log.verbose('fetch fusion sites start', options as any);
@@ -132,9 +132,7 @@ export default class FusionSDK {
       }, this.fusionHost);
 
       if (!body.success) {
-        (body.data || []).forEach((fail) =>
-          log.error('FusionSDK:', `物料 ${fail.npm} 上传失败, 原因: ${fail.reason}`)
-        );
+        (body.data || []).forEach((fail) => log.error('FusionSDK:', `物料 ${fail.npm} 上传失败, 原因: ${fail.reason}`));
         throw new Error('物料上传失败');
       }
     };
@@ -161,7 +159,7 @@ export default class FusionSDK {
     }
   }
 
-};
+}
 
 async function requestFusion(options: AxiosRequestConfig, fusionHost: string) {
   try {

--- a/packages/iceworks-cli/src/command/sync/index.ts
+++ b/packages/iceworks-cli/src/command/sync/index.ts
@@ -51,7 +51,7 @@ export default async (options) => {
     fusionToken = await fusionSDK.getToken();
     try {
       await config.set(tokenKey, fusionToken);
-    } catch(err) {
+    } catch (err) {
       log.warn('set token warning', err.message);
     }
   }
@@ -64,7 +64,7 @@ export default async (options) => {
   } else {
     try {
       fusionSite = await fusionSDK.getSite(fusionToken);
-    } catch(err) {
+    } catch (err) {
       if (err.noAuth) {
         // token 失效，重置掉
         await config.set(tokenKey, null);
@@ -77,7 +77,7 @@ export default async (options) => {
     try {
       await fse.writeJson(pkgPath, pkgData, { spaces: 2 });
       log.verbose('Sync:', 'write site success');
-    } catch(err) {
+    } catch (err) {
       log.warn('write site warning', err.message);
       console.error(err);
     }
@@ -91,7 +91,7 @@ export default async (options) => {
     log.info('Sync:', '物料上传完成，可以在 iceworks 中添加自定义物料使用啦！');
     log.info('物料地址：', materialUrl);
     console.log();
-  } catch(err) {
+  } catch (err) {
     if (err.noAuth) {
       // token 失效，重置掉
       await config.set(tokenKey, null);

--- a/packages/iceworks-cli/src/utils/checkEmpty.ts
+++ b/packages/iceworks-cli/src/utils/checkEmpty.ts
@@ -29,4 +29,4 @@ export default function checkEmpty(dir): Promise<boolean> {
       return resolve(true);
     });
   });
-};
+}

--- a/packages/iceworks-cli/src/utils/constants.ts
+++ b/packages/iceworks-cli/src/utils/constants.ts
@@ -4,5 +4,7 @@ import * as userHome from 'user-home';
 export const DB_PATH = 'build/materials.json';
 export const TEMP_PATH = path.join(process.cwd(), '.iceworks-tmp');
 export const CONFIG_PATH = path.join(userHome || __dirname, '.iceworks/cli-config.json');
+// eslint-disable-next-line
 export const TOKEN_KEY = 'fusion-token';
+// eslint-disable-next-line
 export const TOKEN_ALI_KEY = 'fusion-token-ali';

--- a/packages/iceworks-cli/src/utils/extractTarball.ts
+++ b/packages/iceworks-cli/src/utils/extractTarball.ts
@@ -22,7 +22,7 @@ interface IOptions {
 export default function extractTarball({
   tarballURL,
   destDir,
-  progressFunc = (state) => {},
+  progressFunc = () => { },
   formatFilename,
 }: IOptions): Promise<string[]> {
   return new Promise((resolve, reject) => {
@@ -34,7 +34,7 @@ export default function extractTarball({
       request({
         url: tarballURL,
         timeout: 10000,
-      })
+      }),
     )
       .on('progress', (state) => {
         progressFunc(state);
@@ -87,4 +87,4 @@ export default function extractTarball({
           });
       });
   });
-};
+}

--- a/packages/iceworks-cli/src/utils/getNpmRegistry.ts
+++ b/packages/iceworks-cli/src/utils/getNpmRegistry.ts
@@ -2,7 +2,7 @@ import { isAliNpm } from 'ice-npm-utils';
 import config from './config';
 import log from './log';
 
-export default async function(npmName, materialConfig, publishConfig, enableUseTaobao): Promise<string> {
+export default async function (npmName, materialConfig, publishConfig, enableUseTaobao): Promise<string> {
   // 某些场景不能用 taobao 源（generate）
   let registry = enableUseTaobao ? 'https://registry.npm.taobao.org' : 'https://registry.npmjs.org';
   if (publishConfig && publishConfig.registry) {
@@ -23,4 +23,4 @@ export default async function(npmName, materialConfig, publishConfig, enableUseT
 
   log.verbose('getNpmRegistry', registry);
   return registry;
-};
+}

--- a/packages/iceworks-cli/src/utils/getNpmTarball.ts
+++ b/packages/iceworks-cli/src/utils/getNpmTarball.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import * as urlJoin from 'url-join';
-import * as path from 'path';
 import * as semver from 'semver';
 import log from './log';
 
@@ -29,4 +28,4 @@ export default async function getNpmTarball(npm: string, version: string, regist
   }
 
   throw new Error(`${name}@${version} 尚未发布`);
-};
+}

--- a/packages/iceworks-cli/src/utils/getUnpkgHost.ts
+++ b/packages/iceworks-cli/src/utils/getUnpkgHost.ts
@@ -1,7 +1,7 @@
 import { isAliNpm } from 'ice-npm-utils';
 import config from './config';
 
-export default async function(npmName: string, materialConfig): Promise<string> {
+export default async function (npmName: string, materialConfig): Promise<string> {
   let unpkgHost = 'https://unpkg.com';
   if (process.env.UNPKG) {
     // 兼容老的用法
@@ -18,4 +18,4 @@ export default async function(npmName: string, materialConfig): Promise<string> 
   }
 
   return unpkgHost;
-};
+}


### PR DESCRIPTION
@ice/spec 原来依赖的 @typescript-eslint/eslint-plugin 版本过低，导致使用 transform-ts-to-js （需要依赖@typescript-eslint/eslint-plugin@4.x）时，会报错。

1. 使用 @iceworks/spec 代替 @ice/spec 
2. 代码使用 eslint 进行格式化