### PR TITLE
build-plugin-component 支持在 babel-plugin-import 中排除 externals 指定的库

### DIFF
--- a/packages/build-plugin-component/src/compiler/babel.js
+++ b/packages/build-plugin-component/src/compiler/babel.js
@@ -74,10 +74,16 @@ module.exports = function babelCompiler(
   type,
 ) {
   const { rootDir, pkg } = context;
-  const { compilerOptions = {}, babelPlugins = [], babelOptions = [], alias, subComponents } = userOptions;
+  const { compilerOptions = {}, babelPlugins = [], babelOptions = [], alias, subComponents, externals = {} } = userOptions;
+
+  let externalLibNames = [];
+  if (typeof externals === 'object') {
+    externalLibNames = Object.keys(externals);
+  }
+
   // generate DTS for ts files, default is true
   const { declaration = true } = compilerOptions;
-  const componentLibs = analyzePackage(pkg, basicComponents);
+  const componentLibs = analyzePackage(pkg, basicComponents).filter(i => !externalLibNames.includes(i));
   const srcPath = path.join(rootDir, 'src');
   // compile task es and lib
   const compileTargets = ['es', 'lib'];


### PR DESCRIPTION
build-plugin-component 插件对于 `es` 和 `lib` 构建产物， `externals` 中对应的库不做 `babel-plugin-import` 转换。

让后续使用基于该插件构建的组件时，工程或组件的 externals 能正常生效。


close #153 