### PR TITLE
feat(miniapp): update compile miniapp version

### DIFF
--- a/packages/build-plugin-component/CHANGELOG.md
+++ b/packages/build-plugin-component/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 1.7.1
+
+- [chore] update miniapp-compile-config version to 0.2.x
+
 ## 1.7.0
 
 - [feat] support `https` cli option

--- a/packages/build-plugin-component/package.json
+++ b/packages/build-plugin-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-component",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "build plugin for component development",
   "main": "src/index.js",
   "scripts": {
@@ -50,8 +50,8 @@
     "jsx2mp-runtime": "^0.4.15",
     "loader-utils": "^1.2.3",
     "marked": "^2.0.0",
-    "miniapp-builder-shared": "^0.1.4",
-    "miniapp-compile-config": "^0.1.1",
+    "miniapp-builder-shared": "^0.2.10",
+    "miniapp-compile-config": "^0.2.5",
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "postcss-plugin-rpx2vw": "^0.0.2",
     "postcss-preset-env": "^6.7.0",


### PR DESCRIPTION
- [x] 升级 miniapp-compile-config 及 miniapp-builder-shared 依赖至 0.2.x，确保编译时组件工程支持 virtualHost 配置等能力 