### PR TITLE
fix: 🐛 compatible with mini-css-extract-plugin 1.x

### DIFF
--- a/packages/build-plugin-component/CHANGELOG.md
+++ b/packages/build-plugin-component/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.2
+
+- [fix] compatible with mini-css-extract-plugin 1.x.
+
 ## 1.8.1
 
 - [feat] support babelPlugins in `type: rax`.

--- a/packages/build-plugin-component/package.json
+++ b/packages/build-plugin-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-component",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "build plugin for component development",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-component/src/utils/setCSSRule.js
+++ b/packages/build-plugin-component/src/utils/setCSSRule.js
@@ -77,6 +77,9 @@ module.exports = (config, useStylesheetLoader) => {
       .test(/\.scss?$/)
       .use('MiniCssExtractPlugin.loader')
       .loader(MiniCssExtractPlugin.loader)
+      .options({
+        esModule: false,
+      })
       .end()
       .use('css-loader')
       .loader(require.resolve('css-loader'))


### PR DESCRIPTION
- [x] compatible with mini-css-extract-plugin