### PR TITLE
feat: fix React.lazy import analyze fail

### DIFF
--- a/packages/build-plugin-component/src/compiler/depAnalyze.js
+++ b/packages/build-plugin-component/src/compiler/depAnalyze.js
@@ -92,9 +92,13 @@ function analyzeAST(code) {
   const visitor = {
     CallExpression(nodePath) {
       const { callee, arguments: args } = nodePath.node;
-      if (
+      const isImportNode = (
         callee.type === 'Identifier' &&
-        callee.name === 'require' &&
+        callee.name === 'require'
+      ) || callee.type === 'Import';
+
+      if (
+        isImportNode &&
         args.length === 1 &&
         args[0].type === 'StringLiteral'
       ) {


### PR DESCRIPTION
修复再对es目录进行依赖分析时，React.lazy里面进行import的模块没有被分析出来

```js
var PlatformMap = {
  mobile: /*#__PURE__*/React.lazy(function () {
    return import('./mobile');
  })
};
```