### PR TITLE
[plugin-component] release build-plugin-component/1.9.4

### DIFF
--- a/examples/react-component/build.json
+++ b/examples/react-component/build.json
@@ -1,17 +1,9 @@
 {
+  "basicComponents": ["@formily/next-components"],
   "htmlInjection": {
     "headAppend": ["<link href=\"test.css\">"]
   },
   "plugins": [
-    "build-plugin-component",
-    "build-plugin-fusion",
-    [
-      "build-plugin-moment-locales",
-      {
-        "locales": [
-          "zh-cn"
-        ]
-      }
-    ]
+    "build-plugin-component"
   ]
 }

--- a/examples/react-component/package.json
+++ b/examples/react-component/package.json
@@ -24,11 +24,11 @@
     "component"
   ],
   "dependencies": {
+    "@formily/next-components": "^1.3.17",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "@alib/build-scripts": "^0.1.3",
-    "build-plugin-component": "^1.0.0",
     "build-plugin-fusion": "^0.1.0",
     "build-plugin-moment-locales": "^0.1.0",
     "react": "^16.3.0",

--- a/examples/react-component/src/index.tsx
+++ b/examples/react-component/src/index.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+import {DatePicker} from '@formily/next-components';
+
+console.log(111, DatePicker);
 
 type ComponentProps = {
   title: string,

--- a/packages/build-plugin-component/CHANGELOG.md
+++ b/packages/build-plugin-component/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.9.4
+
+- [fix] styles will missing in style.js if React.lazy is used，where dynamic import is ignored by ASTParser ([#260](https://github.com/ice-lab/iceworks-cli/pull/260))
+
+```
+var PlatformMap = {
+  mobile: /*#__PURE__*/React.lazy(function () {
+    return import('./mobile');
+  })
+};
+```
+
 ## 1.9.3
 
 - [feat] add default cors handler.

--- a/packages/build-plugin-component/CHANGELOG.md
+++ b/packages/build-plugin-component/CHANGELOG.md
@@ -12,6 +12,9 @@ var PlatformMap = {
 };
 ```
 
+- [fix] use babel-plugin-import transform `import { Foo } from 'package'` consider `esm/` libraryDirectory, for `@formily/next-components`
+- [chore] use `require.resolve` transform babel plugins path
+
 ## 1.9.3
 
 - [feat] add default cors handler.

--- a/packages/build-plugin-component/package.json
+++ b/packages/build-plugin-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-component",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "build plugin for component development",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-component/src/compiler/babel.js
+++ b/packages/build-plugin-component/src/compiler/babel.js
@@ -52,10 +52,16 @@ const getBabelConfig = ({
       style: false, // style file will be require in style.js
     };
     if (target === 'es') {
-      const libPath = path.join(rootDir, 'node_modules', libraryName, 'es');
-      if (fs.existsSync(libPath)) {
-        pluginOption.libraryDirectory = 'es';
-      }
+      ['es', 'esm'].some((item) => {
+        const dirPath = path.join(rootDir, 'node_modules', libraryName, item);
+        const dirExist = fs.existsSync(dirPath);
+
+        if (dirExist) {
+          pluginOption.libraryDirectory = item;
+        }
+
+        return dirExist;
+      });
     }
     plugins.push([
       require.resolve('babel-plugin-import'),

--- a/packages/build-plugin-component/src/compiler/depAnalyze.js
+++ b/packages/build-plugin-component/src/compiler/depAnalyze.js
@@ -92,9 +92,13 @@ function analyzeAST(code) {
   const visitor = {
     CallExpression(nodePath) {
       const { callee, arguments: args } = nodePath.node;
-      if (
+      const isImportNode = (
         callee.type === 'Identifier' &&
-        callee.name === 'require' &&
+        callee.name === 'require'
+      ) || callee.type === 'Import';
+
+      if (
+        isImportNode &&
         args.length === 1 &&
         args[0].type === 'StringLiteral'
       ) {

--- a/packages/build-plugin-component/src/utils/getCompileBabel.js
+++ b/packages/build-plugin-component/src/utils/getCompileBabel.js
@@ -7,30 +7,26 @@ module.exports = (options = {}, { babelPlugins, babelOptions, rootDir }) => {
   const defaultBabel = getBabelConfig();
 
   const additionalPlugins = [
-    ['@babel/plugin-transform-runtime', {
+    [require.resolve('@babel/plugin-transform-runtime'), {
       corejs: false,
       helpers: true,
       regenerator: true,
       useESModules: false,
     }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-private-methods', { loose: true }],
-    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
+    [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
+    [require.resolve('@babel/plugin-proposal-private-methods'), { loose: true }],
+    [require.resolve('@babel/plugin-proposal-private-property-in-object'), { loose: true }],
   ];
 
-  defaultBabel.plugins = [...defaultBabel.plugins, ...additionalPlugins, ...((babelPlugins || []).map((plugin) => {
-    const [plguinName, pluginOptions, ...restOptions] = Array.isArray(plugin) ? plugin : [plugin];
-    const pluginPath = require.resolve(plguinName, { paths: [rootDir] });
-    if (pluginOptions) {
-      return [
-        pluginPath,
-        pluginOptions,
-        ...(restOptions || []),
-      ];
-    } else {
-      return pluginPath;
-    }
-  }))];
+  const formatedBabelPlugins = (babelPlugins || []).map((plugin) => {
+    const [pluginName, pluginOptions, ...restOptions] = Array.isArray(plugin) ? plugin : [plugin];
+    // 用户自定义的 babelPlugins 需要从项目目录寻址
+    const pluginPath = require.resolve(pluginName, { paths: [rootDir] });
+    return pluginOptions ? [pluginPath, pluginOptions, ...(restOptions || [])] : pluginPath;
+  });
+
+  defaultBabel.plugins = [...defaultBabel.plugins, ...additionalPlugins, ...formatedBabelPlugins];
+
   // modify @babel/preset-env options
   defaultBabel.presets = defaultBabel.presets.map((preset) => {
     const [presetPath, presetOptions] = Array.isArray(preset) ? preset : [preset];


### PR DESCRIPTION
- [x] 修复生成 style.js 为遍历动态 import，导致使用 React.lazy 会缺少样式 Closes https://github.com/ice-lab/iceworks-cli/pull/260
- [x] 按需加载考虑目录为 esm/ 的场景，比如 `@formily/next-components`