### PR TITLE
[plugin-component-screenshot] feat: write screenshots.json

### DIFF
--- a/packages/build-plugin-component-screenshot/CHANGELOG.md
+++ b/packages/build-plugin-component-screenshot/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Changelog
+
+## 0.2.0
+
+- feat: write `build/screenshots.json`

--- a/packages/build-plugin-component-screenshot/CHANGELOG.md
+++ b/packages/build-plugin-component-screenshot/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 0.2.0
 
 - feat: write `build/screenshots.json`
+- feat: enable on cloud environment

--- a/packages/build-plugin-component-screenshot/CHANGELOG.md
+++ b/packages/build-plugin-component-screenshot/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0
+## 1.0.0
 
 - feat: write `build/screenshots.json`
 - feat: enable on cloud environment

--- a/packages/build-plugin-component-screenshot/README.md
+++ b/packages/build-plugin-component-screenshot/README.md
@@ -1,33 +1,20 @@
 # build-plugin-component-screenshot
 
-build-plugin-component截图插件
+build-plugin-component 截图插件
+
+### 安装
+
+```
+npm i -D build-plugin-component-screenshot puppeteer
+```
 
 ### build.json 配置
-默认会在云构建环境下执行（目前还不支持）
 
 ```
 {
   "plugins": [
-    "build-plugin-component-screenshot",
     "build-plugin-component",
-    "..."
+    "build-plugin-component-screenshot"
   ]
 }
-
-```
-
-目前云构建环境还不支持截图能力，避免云构建环境下报错，需配置关闭云构建下的截图插件
-
-
-```
-{
-  "plugins": [
-    ["build-plugin-component-screenshot", {
-      "cloud": false
-    }],
-    "build-plugin-component",
-    "..."
-  ]
-}
-
 ```

--- a/packages/build-plugin-component-screenshot/package.json
+++ b/packages/build-plugin-component-screenshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-component-screenshot",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "build plugin for component development screenshot",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-component-screenshot/package.json
+++ b/packages/build-plugin-component-screenshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-component-screenshot",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "build plugin for component development screenshot",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-component-screenshot/src/index.js
+++ b/packages/build-plugin-component-screenshot/src/index.js
@@ -5,10 +5,7 @@ const screenshotWithLocalServer = require('./screenshot');
 
 const DEFAULT_PORT = 8100;
 
-module.exports = (
-  { context, onHook, log },
-  pluginOptions = {},
-) => {
+module.exports = ({ context, onHook, log }, pluginOptions = {}) => {
   const { rootDir, pkg } = context;
   const { cloud = false } = pluginOptions;
   onHook('after.build.compile', async () => {
@@ -31,13 +28,14 @@ module.exports = (
     debug('viewsPath', viewsPath);
     const demos = (await fse.readdir(demoPath)) || [];
     debug('demos', demos);
-    const selectors = demos.filter(item => /^.*\.md$/g.test(item)).map(item => item.replace(/\.md$/g, ''));
+    const selectors = demos.filter((item) => /^.*\.md$/g.test(item)).map((item) => item.replace(/\.md$/g, ''));
     debug('selectors', selectors);
     if (!selectors.length) {
       return;
     }
     const snapshots = await screenshotWithLocalServer(serverPath, port, targetUrl, selectors, viewsPath);
     debug('snapshots', snapshots);
+    fse.writeFileSync(`${rootDir}/build/screenshots.json`, JSON.stringify(snapshots));
     pkg.snapshots = snapshots;
   });
 };

--- a/packages/build-plugin-component-screenshot/src/index.js
+++ b/packages/build-plugin-component-screenshot/src/index.js
@@ -5,16 +5,9 @@ const screenshotWithLocalServer = require('./screenshot');
 
 const DEFAULT_PORT = 8100;
 
-module.exports = ({ context, onHook, log }, pluginOptions = {}) => {
+module.exports = ({ context, onHook, log }) => {
   const { rootDir, pkg } = context;
-  const { cloud = false } = pluginOptions;
   onHook('after.build.compile', async () => {
-    debug('cloud', cloud);
-    // cloud build support
-    if (!cloud && process.env.BUILD_ENV === 'cloud') {
-      log.warn('current environment not support screenshot');
-      return;
-    }
     log.info('generate demo snapshot ...');
     const demoPath = `${rootDir}/demo`;
     const serverPath = `${rootDir}/build`;


### PR DESCRIPTION
我们想在组件展示平台展示组件的截图，但是构建之后的截图文件名无法被组件展示平台获取。因此需要一个固定路径的 JSON 文件存储所有截图文件的相对路径。此 PR 会生成 `build/screenshots.json` 文件，内容为：

```json
[
  "views/basic.png",
  "views/disable-row-actions.png",
  "views/fixed-height.png",
  "views/hide-checkboxes.png",
  "views/hide-footer.png",
  "views/small.png"
]
```

另外，目前 DEF 云构建已经支持 puppeteer 了，因此不再需要 cloud 选项。同时需要增加选项 `{ args: ['--no-sandbox'] }` 才能云构建。