### PR TITLE
fix(ice-npm-utils): fix sort problem in getLatestSemverVersion

### DIFF
--- a/packages/ice-npm-utils/src/index.ts
+++ b/packages/ice-npm-utils/src/index.ts
@@ -159,7 +159,7 @@ function getLatestSemverVersion(baseVersion: string, versions: string[]): string
   versions = versions
     .filter((version) => semver.satisfies(version, `^${baseVersion}`))
     .sort((a, b) => {
-      return semver.gt(b, a);
+      return semver.gt(b, a) ? 1 : -1;
     });
   return versions[0];
 }


### PR DESCRIPTION
According to the description of sort on [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description), the compareFunction should return a number.

![image](https://user-images.githubusercontent.com/2311742/158414318-c6e65a5d-5395-41fc-954d-e0f936645850.png)

The current implementation is not working properly, see the following simple test which can be copy and executed in the browser console.

```js
[  '0.2.4', '0.2.5' ].sort((a, b) => {
  return b > a;
});
// console ['0.2.4', '0.2.5']
```

```js
[  '0.2.4', '0.2.5' ].sort((a, b) => {
  return b > a ? 1 : -1;
});
// console ['0.2.5', '0.2.4']
```